### PR TITLE
Standardize logging middleware format

### DIFF
--- a/middlewares.go
+++ b/middlewares.go
@@ -42,7 +42,7 @@ func (mw loggingMiddleware) Uppercase(ctx context.Context, s string) (output str
 func (mw loggingMiddleware) Count(ctx context.Context, s string) (n int) {
 	defer func(begin time.Time) {
 		logfmt := logfmtStruct{
-			"uppercase",
+			"count",
 			s,
 			n,
 			nil,

--- a/middlewares.go
+++ b/middlewares.go
@@ -25,7 +25,7 @@ type loggingMiddleware struct {
 }
 
 func (mw loggingMiddleware) Log(method string, input, output interface{}, err error, took time.Duration) error {
-	logfmt := logfmtStruct{
+	logfmt := logfmt{
 		method,
 		input,
 		output,
@@ -63,8 +63,8 @@ func (mw loggingMiddleware) Count(ctx context.Context, s string) (n int) {
 	return mw.next.Count(ctx, s)
 }
 
-// logfmtStruct contains logfmt-style logging fields
-type logfmtStruct struct {
+// logfmt contains logfmt-style logging fields
+type logfmt struct {
 	method        string
 	input, output interface{}
 	err           error
@@ -72,12 +72,12 @@ type logfmtStruct struct {
 }
 
 // keyvals return key-val pairs to feed to go-kit/log.Logger.Log() method
-func (s *logfmtStruct) keyvals() []interface{} {
+func (f *logfmt) keyvals() []interface{} {
 	return []interface{}{
-		"method", s.method,
-		"input", s.input,
-		"output", s.output,
-		"err", s.err,
-		"took", s.took,
+		"method", f.method,
+		"input", f.input,
+		"output", f.output,
+		"err", f.err,
+		"took", f.took,
 	}
 }

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -2,6 +2,7 @@ package stringsvc_test
 
 import (
 	"bytes"
+	"flag"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/gnhuy91/stringsvc"
 )
+
+var debug bool
+
+func init() {
+	flag.BoolVar(&debug, "debug", false, "")
+	flag.Parse()
+}
 
 type service struct {
 	UppercaseF func(context.Context, string) (string, error)
@@ -40,8 +48,11 @@ func TestLogMiddlewareUppercase(t *testing.T) {
 	ctx := context.Background()
 
 	var logBuf bytes.Buffer
-	wr := io.MultiWriter(&logBuf, os.Stderr)
-	logger := log.NewLogfmtLogger(wr)
+	logw := io.MultiWriter(&logBuf)
+	if debug {
+		logw = io.MultiWriter(logw, os.Stderr)
+	}
+	logger := log.NewLogfmtLogger(logw)
 
 	svc := &service{}
 	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
@@ -58,8 +69,11 @@ func TestLogMiddlewareCount(t *testing.T) {
 	ctx := context.Background()
 
 	var logBuf bytes.Buffer
-	wr := io.MultiWriter(&logBuf, os.Stderr)
-	logger := log.NewLogfmtLogger(wr)
+	logw := io.MultiWriter(&logBuf)
+	if debug {
+		logw = io.MultiWriter(logw, os.Stderr)
+	}
+	logger := log.NewLogfmtLogger(logw)
 
 	svc := &service{}
 	logSvc := stringsvc.LoggingMiddleware(logger)(svc)

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -47,12 +47,14 @@ var (
 func TestLogMiddlewareUppercase(t *testing.T) {
 	ctx := context.Background()
 
-	var logBuf bytes.Buffer
-	logw := io.MultiWriter(&logBuf)
-	if debug {
-		logw = io.MultiWriter(logw, os.Stderr)
+	var buf bytes.Buffer
+	var logger log.Logger
+	{
+		logger = log.NewLogfmtLogger(&buf)
+		if debug {
+			logger = log.NewLogfmtLogger(io.MultiWriter(&buf, os.Stderr))
+		}
 	}
-	logger := log.NewLogfmtLogger(logw)
 
 	svc := &service{}
 	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
@@ -62,18 +64,20 @@ func TestLogMiddlewareUppercase(t *testing.T) {
 	}
 	logSvc.Uppercase(ctx, "")
 
-	testLogFmt(t, logBuf, "uppercase")
+	testLogFmt(t, buf, "uppercase")
 }
 
 func TestLogMiddlewareCount(t *testing.T) {
 	ctx := context.Background()
 
-	var logBuf bytes.Buffer
-	logw := io.MultiWriter(&logBuf)
-	if debug {
-		logw = io.MultiWriter(logw, os.Stderr)
+	var buf bytes.Buffer
+	var logger log.Logger
+	{
+		logger = log.NewLogfmtLogger(&buf)
+		if debug {
+			logger = log.NewLogfmtLogger(io.MultiWriter(&buf, os.Stderr))
+		}
 	}
-	logger := log.NewLogfmtLogger(logw)
 
 	svc := &service{}
 	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
@@ -83,7 +87,7 @@ func TestLogMiddlewareCount(t *testing.T) {
 	}
 	logSvc.Count(ctx, "")
 
-	testLogFmt(t, logBuf, "count")
+	testLogFmt(t, buf, "count")
 }
 
 func testLogFmt(t *testing.T, logOutput bytes.Buffer, method string) {

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -56,13 +56,13 @@ func TestLogMiddlewareUppercase(t *testing.T) {
 		}
 	}
 
-	svc := &service{}
-	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
-
-	svc.UppercaseF = func(ctx context.Context, s string) (string, error) {
-		return "", nil
+	svc := &service{
+		UppercaseF: func(ctx context.Context, s string) (string, error) {
+			return "", nil
+		},
 	}
-	logSvc.Uppercase(ctx, "")
+	logMw := stringsvc.LoggingMiddleware(logger)(svc)
+	logMw.Uppercase(ctx, "")
 
 	testLogFmt(t, buf, "uppercase")
 }
@@ -79,13 +79,13 @@ func TestLogMiddlewareCount(t *testing.T) {
 		}
 	}
 
-	svc := &service{}
-	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
-
-	svc.CountF = func(ctx context.Context, s string) int {
-		return 0
+	svc := &service{
+		CountF: func(ctx context.Context, s string) int {
+			return 0
+		},
 	}
-	logSvc.Count(ctx, "")
+	logMw := stringsvc.LoggingMiddleware(logger)(svc)
+	logMw.Count(ctx, "")
 
 	testLogFmt(t, buf, "count")
 }

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -1,0 +1,88 @@
+package stringsvc_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"golang.org/x/net/context"
+
+	"github.com/gnhuy91/stringsvc"
+)
+
+type service struct {
+	UppercaseF func(context.Context, string) (string, error)
+	CountF     func(context.Context, string) int
+}
+
+func (svc *service) Uppercase(ctx context.Context, s string) (string, error) {
+	return svc.UppercaseF(ctx, s)
+}
+
+func (svc *service) Count(ctx context.Context, s string) (n int) {
+	return svc.CountF(ctx, s)
+}
+
+var (
+	logfmtRegex  = `^method=(\S+) input=("*[a-zA-Z0-9_ ]*"*) output=("*[a-zA-Z0-9_ ]*"*) err=("*[a-zA-Z0-9_ ]*"*) took=(\S+)$`
+	methodPrefix = `method=`
+)
+
+func TestLogFmtUppercase(t *testing.T) {
+	ctx := context.Background()
+
+	var logBuf bytes.Buffer
+	wr := io.MultiWriter(&logBuf, os.Stderr)
+	logger := log.NewLogfmtLogger(wr)
+
+	svc := &service{}
+	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
+
+	svc.UppercaseF = func(ctx context.Context, s string) (string, error) {
+		return "", nil
+	}
+	logSvc.Uppercase(ctx, "")
+
+	testLogFmt(t, logBuf, "uppercase")
+}
+
+func TestLogFmtCount(t *testing.T) {
+	ctx := context.Background()
+
+	var logBuf bytes.Buffer
+	wr := io.MultiWriter(&logBuf, os.Stderr)
+	logger := log.NewLogfmtLogger(wr)
+
+	svc := &service{}
+	logSvc := stringsvc.LoggingMiddleware(logger)(svc)
+
+	svc.CountF = func(ctx context.Context, s string) int {
+		return 0
+	}
+	logSvc.Count(ctx, "")
+
+	testLogFmt(t, logBuf, "count")
+}
+
+func testLogFmt(t *testing.T, logOutput bytes.Buffer, method string) {
+	b, err := ioutil.ReadAll(&logOutput)
+	if err != nil {
+		t.Error(err)
+	}
+	b = bytes.TrimSpace(b)
+	match, err := regexp.Match(logfmtRegex, b)
+	if err != nil {
+		t.Error(err)
+	}
+	if !match {
+		t.Errorf("log output does not match regex %q, ouput %q", logfmtRegex, b)
+	}
+	prefix := []byte(methodPrefix + method)
+	if !bytes.HasPrefix(b, prefix) {
+		t.Errorf("log output method does not match, want prefix %q, got %q", prefix, b)
+	}
+}

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -28,7 +28,11 @@ func (svc *service) Count(ctx context.Context, s string) (n int) {
 }
 
 var (
-	logfmtRegex  = `^method=(\S+) input=("*[a-zA-Z0-9_ ]*"*) output=("*[a-zA-Z0-9_ ]*"*) err=("*[a-zA-Z0-9_ ]*"*) took=(\S+)$`
+	logfmtRegex = `^method=(\S+) ` +
+		`input=("*[a-zA-Z0-9_ ]*"*) ` +
+		`output=("*[a-zA-Z0-9_ ]*"*) ` +
+		`err=("*[a-zA-Z0-9_ ]*"*) ` +
+		`took=(\S+)$`
 	methodPrefix = `method=`
 )
 

--- a/middlewares_test.go
+++ b/middlewares_test.go
@@ -36,7 +36,7 @@ var (
 	methodPrefix = `method=`
 )
 
-func TestLogFmtUppercase(t *testing.T) {
+func TestLogMiddlewareUppercase(t *testing.T) {
 	ctx := context.Background()
 
 	var logBuf bytes.Buffer
@@ -54,7 +54,7 @@ func TestLogFmtUppercase(t *testing.T) {
 	testLogFmt(t, logBuf, "uppercase")
 }
 
-func TestLogFmtCount(t *testing.T) {
+func TestLogMiddlewareCount(t *testing.T) {
 	ctx := context.Background()
 
 	var logBuf bytes.Buffer

--- a/service_test.go
+++ b/service_test.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	. "github.com/gnhuy91/stringsvc"
+	"github.com/gnhuy91/stringsvc"
 )
 
 func TestUppercase(t *testing.T) {
@@ -15,7 +15,7 @@ func TestUppercase(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	svc := NewStringService()
+	svc := stringsvc.NewStringService()
 
 	s, err := svc.Uppercase(ctx, inp)
 	if err != nil {
@@ -32,11 +32,11 @@ func TestUppercase_FailIfInputNil(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	svc := NewStringService()
+	svc := stringsvc.NewStringService()
 
 	_, err := svc.Uppercase(ctx, inp)
-	if err != ErrEmpty {
-		t.Errorf("input: %q, want %q, got %q", inp, ErrEmpty.Error(), err.Error())
+	if err != stringsvc.ErrEmpty {
+		t.Errorf("input: %q, want %q, got %q", inp, stringsvc.ErrEmpty, err)
 	}
 }
 
@@ -47,7 +47,7 @@ func TestCount(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	svc := NewStringService()
+	svc := stringsvc.NewStringService()
 
 	n := svc.Count(ctx, inp)
 	if n != outp {

--- a/transport_test.go
+++ b/transport_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"golang.org/x/net/context"
 
-	. "github.com/gnhuy91/stringsvc"
+	"github.com/gnhuy91/stringsvc"
 )
 
 func TestHandlerUppercase(t *testing.T) {
@@ -24,8 +24,8 @@ func TestHandlerUppercase(t *testing.T) {
 
 	ctx := context.Background()
 	logger := log.NewLogfmtLogger(os.Stderr)
-	s := NewStringService()
-	h := MakeHTTPHandler(ctx, s, logger)
+	s := stringsvc.NewStringService()
+	h := stringsvc.MakeHTTPHandler(ctx, s, logger)
 
 	req, _ := http.NewRequest(method, url, strings.NewReader(reqBody))
 	rec := httptest.NewRecorder()
@@ -54,8 +54,8 @@ func TestHandlerCount(t *testing.T) {
 
 	ctx := context.Background()
 	logger := log.NewLogfmtLogger(os.Stderr)
-	s := NewStringService()
-	h := MakeHTTPHandler(ctx, s, logger)
+	s := stringsvc.NewStringService()
+	h := stringsvc.MakeHTTPHandler(ctx, s, logger)
 
 	req, _ := http.NewRequest(method, url, strings.NewReader(reqBody))
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
Introduce a struct to pre-define logfmt fields to feed to `go-kit/log.Logger.Log()` method.